### PR TITLE
Add support for `merge()` and `context()`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,55 @@ $User = UserFactory::factory()->make();
 echo $User->first_name; // 'Jane'
 echo $User->last_name;  // 'Doe'
 ```
+
+## Using the `merge()` Method
+
+Sometimes it is useful to merge new values into the current context of the factory.
+
+Use the `merge()` method to merge any new values and update the factory context.
+
+```php
+class UserFactory
+{
+    use \Zerotoprod\DataModelFactory\Factory;
+
+    private function definition(): array
+    {
+        return [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+        ];
+    }
+}
+
+$User = UserFactory::factory()
+    ->merge(['first_name' => 'Jane'])
+    ->make();
+
+echo $User->first_name; // 'Jane'
+echo $User->last_name;  // 'Doe'
+```
+
+## Using the `context()` Method
+
+Use the `context()` method to get the context of the factory.
+
+```php
+class UserFactory
+{
+    use \Zerotoprod\DataModelFactory\Factory;
+
+    private function definition(): array
+    {
+        return [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+        ];
+    }
+}
+
+$User = UserFactory::factory()->context();
+
+echo $User['first_name']; // 'John'
+echo $User['last_name'];  // 'Doe'
+```

--- a/README.md
+++ b/README.md
@@ -9,12 +9,23 @@
 [![Packagist Version](https://img.shields.io/packagist/v/zero-to-prod/data-model-factory?color=f28d1a)](https://packagist.org/packages/zero-to-prod/data-model-factory)
 [![License](https://img.shields.io/packagist/l/zero-to-prod/data-model-factory?color=pink)](https://github.com/zero-to-prod/data-model-factory/blob/main/LICENSE.md)
 
+Zerotoprod\DataModelFactory
+
+- [Introduction](#introduction)
+- [Installation](#installation)
+    - [Additional Packages](#additional-packages)
+- [Usage](#usage)
+    - [Custom Class Instantiation](#custom-class-instantiation)
+    - [The `set()` Method](#the-set-method)
+    - [The `merge()` Method](#the-merge-method)
+    - [The `context()` Method](#the-context-method)
+
 ## Introduction
 
 This package is a fresh take on how to set the state of your DTOs in a simple and delightful way.
 
 The API is takes some hints from Laravel's Eloquent [Factories](https://laravel.com/docs/11.x/eloquent-factories), but adds some niceties such as
-setting state via dot syntax and using the [set()](#using-the-set-method) helper method on the fly.
+setting state via dot syntax and using the [set()](#the-set-method) helper method on the fly.
 
 This package does not require any other dependencies, allowing you to make a factory for anything.
 
@@ -122,29 +133,7 @@ echo $User->first_name; // 'Jane'
 echo $User->last_name;  // 'Doe'
 ```
 
-## Using the `set()` Method
-
-You can use the `set()` helper method to fluently modify the state of your model in a convenient way.
-
-This is a great way to modify a model without having to implement a method in the factory.
-
-```php
-$User = User::factory()
-            ->set('first_name', 'John')
-            ->set(['last_name' => 'Doe'])
-            ->set(function ($context) {
-                return ['surname' => $context['last_name']];
-            })
-            ->set('address.postal_code', '46789') // dot syntax for nested values 
-            ->make();
-
-echo $User->first_name;             // John
-echo $User->last_name;              // Doe
-echo $User->surname;                // Doe
-echo $User->address->postal_code;   // 46789
-```
-
-## Custom Class Instantiation
+### Custom Class Instantiation
 
 To customize instantiation, override the `make()` method.
 
@@ -180,7 +169,29 @@ echo $User->first_name; // 'Jane'
 echo $User->last_name;  // 'Doe'
 ```
 
-## Using the `merge()` Method
+### The `set()` Method
+
+You can use the `set()` helper method to fluently modify the state of your model in a convenient way.
+
+This is a great way to modify a model without having to implement a method in the factory.
+
+```php
+$User = User::factory()
+            ->set('first_name', 'John')
+            ->set(['last_name' => 'Doe'])
+            ->set(function ($context) {
+                return ['surname' => $context['last_name']];
+            })
+            ->set('address.postal_code', '46789') // dot syntax for nested values 
+            ->make();
+
+echo $User->first_name;             // John
+echo $User->last_name;              // Doe
+echo $User->surname;                // Doe
+echo $User->address->postal_code;   // 46789
+```
+
+### The `merge()` Method
 
 Sometimes it is useful to merge new values into the current context of the factory.
 
@@ -208,7 +219,7 @@ echo $User->first_name; // 'Jane'
 echo $User->last_name;  // 'Doe'
 ```
 
-## Using the `context()` Method
+### The `context()` Method
 
 Use the `context()` method to get the context of the factory.
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 [![Packagist Version](https://img.shields.io/packagist/v/zero-to-prod/data-model-factory?color=f28d1a)](https://packagist.org/packages/zero-to-prod/data-model-factory)
 [![License](https://img.shields.io/packagist/l/zero-to-prod/data-model-factory?color=pink)](https://github.com/zero-to-prod/data-model-factory/blob/main/LICENSE.md)
 
-Zerotoprod\DataModelFactory
-
 - [Introduction](#introduction)
 - [Installation](#installation)
     - [Additional Packages](#additional-packages)

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -45,8 +45,6 @@ namespace Zerotoprod\DataModelFactory;
  * @link https://github.com/zero-to-prod/data-model-factory
  *
  * @see  https://github.com/zero-to-prod/data-model
- * @see  https://github.com/zero-to-prod/data-model-helper
- * @see  https://github.com/zero-to-prod/transformable
  */
 trait Factory
 {
@@ -58,8 +56,6 @@ trait Factory
      * @link https://github.com/zero-to-prod/data-model-factory
      *
      * @see  https://github.com/zero-to-prod/data-model
-     * @see  https://github.com/zero-to-prod/data-model-helper
-     * @see  https://github.com/zero-to-prod/transformable
      */
     private $context;
 
@@ -69,8 +65,6 @@ trait Factory
      * @link https://github.com/zero-to-prod/data-model-factory
      *
      * @see  https://github.com/zero-to-prod/data-model
-     * @see  https://github.com/zero-to-prod/data-model-helper
-     * @see  https://github.com/zero-to-prod/transformable
      */
     public function __construct(array $context = [])
     {
@@ -85,12 +79,38 @@ trait Factory
      * @link https://github.com/zero-to-prod/data-model-factory
      *
      * @see  https://github.com/zero-to-prod/data-model
-     * @see  https://github.com/zero-to-prod/data-model-helper
-     * @see  https://github.com/zero-to-prod/transformable
      */
     private function definition(): array
     {
         return [];
+    }
+
+    /**
+     * Merge the context with the new values.
+     *
+     * @link https://github.com/zero-to-prod/data-model-factory
+     *
+     * @see  https://github.com/zero-to-prod/data-model
+     */
+    public function merge(array $definition = []): self
+    {
+        $this->context = array_merge($this->context, $definition);
+
+        return $this;
+    }
+
+    /**
+     * Merge the context with the new values and return the new context.
+     *
+     * @return array<string, mixed>
+     *
+     * @link https://github.com/zero-to-prod/data-model-factory
+     *
+     * @see  https://github.com/zero-to-prod/data-model
+     */
+    public function context(): array
+    {
+        return $this->context;
     }
 
     /**
@@ -101,8 +121,6 @@ trait Factory
      * @link https://github.com/zero-to-prod/data-model-factory
      *
      * @see  https://github.com/zero-to-prod/data-model
-     * @see  https://github.com/zero-to-prod/data-model-helper
-     * @see  https://github.com/zero-to-prod/transformable
      */
     public static function factory(array $context = []): self
     {
@@ -115,8 +133,6 @@ trait Factory
      * @link https://github.com/zero-to-prod/data-model-factory
      *
      * @see  https://github.com/zero-to-prod/data-model
-     * @see  https://github.com/zero-to-prod/data-model-helper
-     * @see  https://github.com/zero-to-prod/transformable
      */
     private function instantiate()
     {
@@ -136,8 +152,6 @@ trait Factory
      * @link https://github.com/zero-to-prod/data-model-factory
      *
      * @see  https://github.com/zero-to-prod/data-model
-     * @see  https://github.com/zero-to-prod/data-model-helper
-     * @see  https://github.com/zero-to-prod/transformable
      */
     public function make()
     {
@@ -173,8 +187,6 @@ trait Factory
      * @link https://github.com/zero-to-prod/data-model-factory
      *
      * @see  https://github.com/zero-to-prod/data-model
-     * @see  https://github.com/zero-to-prod/data-model-helper
-     * @see  https://github.com/zero-to-prod/transformable
      */
     private function state($state, $value = null): self
     {
@@ -230,8 +242,6 @@ trait Factory
      * @link https://github.com/zero-to-prod/data-model-factory
      *
      * @see  https://github.com/zero-to-prod/data-model
-     * @see  https://github.com/zero-to-prod/data-model-helper
-     * @see  https://github.com/zero-to-prod/transformable
      */
     public function set($state, $value = null): self
     {

--- a/tests/Unit/Context/ContextTest.php
+++ b/tests/Unit/Context/ContextTest.php
@@ -18,4 +18,17 @@ class ContextTest extends TestCase
         self::assertEquals('John', $User->first_name);
         self::assertEquals('Doe', $User->last_name);
     }
+
+    /**
+     * @test
+     *
+     * @see Factory
+     */
+    public function context(): void
+    {
+        $User = User::factory([User::last_name => 'Doe'])->context();
+
+        self::assertEquals('John', $User[User::first_name]);
+        self::assertEquals('Doe', $User[User::last_name]);
+    }
 }

--- a/tests/Unit/Merge/FactoryTest.php
+++ b/tests/Unit/Merge/FactoryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit\Merge;
+
+use Tests\TestCase;
+
+class FactoryTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @see Factory
+     */
+    public function merge(): void
+    {
+        $User = UserFactory::factory()
+            ->set(User::first_name, 'John')
+            ->set([User::last_name => 'Doe'])
+            ->set(function (array $context) {
+                return [User::surname => $context[User::last_name]];
+            })
+            ->set('address.postal_code', '46789')
+            ->merge([User::last_name => 'merged'])
+            ->make();
+
+        self::assertEquals('John', $User->first_name);
+        self::assertEquals('merged', $User->last_name);
+        self::assertEquals('Doe', $User->surname);
+        self::assertEquals('46789', $User->address['postal_code']);
+    }
+}

--- a/tests/Unit/Merge/User.php
+++ b/tests/Unit/Merge/User.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Unit\Merge;
+
+use Tests\Unit\DataModel;
+
+class User
+{
+    use DataModel;
+
+    public const first_name = 'first_name';
+    public const last_name = 'last_name';
+    public const surname = 'surname';
+    public const address = 'address';
+    public $first_name;
+    public $last_name;
+    public $surname;
+    public $address;
+}

--- a/tests/Unit/Merge/UserFactory.php
+++ b/tests/Unit/Merge/UserFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Unit\Merge;
+
+use Zerotoprod\DataModelFactory\Factory;
+
+class UserFactory
+{
+    use Factory;
+
+    protected $model = User::class;
+
+    protected function definition(): array
+    {
+        return [
+            User::first_name => 'John',
+            User::last_name => 'N/A',
+            User::address => [
+                'postal_code' => 'a',
+            ],
+        ];
+    }
+
+    public function make(): User
+    {
+        return $this->instantiate();
+    }
+}


### PR DESCRIPTION
## Description

## Using the `merge()` Method

Sometimes it is useful to merge new values into the current context of the factory.

Use the `merge()` method to merge any new values and update the factory context.

```php
class UserFactory
{
    use \Zerotoprod\DataModelFactory\Factory;

    private function definition(): array
    {
        return [
            'first_name' => 'John',
            'last_name' => 'Doe',
        ];
    }
}

$User = UserFactory::factory()
    ->merge(['first_name' => 'Jane'])
    ->make();

echo $User->first_name; // 'Jane'
echo $User->last_name;  // 'Doe'
```

## Using the `context()` Method

Use the `context()` method to get the context of the factory.

```php
class UserFactory
{
    use \Zerotoprod\DataModelFactory\Factory;

    private function definition(): array
    {
        return [
            'first_name' => 'John',
            'last_name' => 'Doe',
        ];
    }
}

$User = UserFactory::factory()->context();

echo $User['first_name']; // 'John'
echo $User['last_name'];  // 'Doe'
```